### PR TITLE
Add Redis support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,13 +19,15 @@ libraryDependencies ++= {
     "io.spray"            %%  "spray-routing"   % sprayV,
     "io.spray"            %%  "spray-client"    % sprayV,
     "io.spray"            %%  "spray-caching"   % sprayV,
-    "io.spray"            %%  "spray-testkit"   % sprayV   % "test",
     "com.typesafe.akka"   %%  "akka-actor"      % akkaV,
     "com.typesafe.akka"   %%  "akka-slf4j"      % akkaV,
+    "net.debasishg"       %%  "redisclient"     % "3.0",
     "ch.qos.logback"      %   "logback-classic" % "1.1.2",
     "org.json4s"          %% "json4s-native"    % "3.2.10",
     "commons-validator"   % "commons-validator" % "1.4.0",
-    "org.scalatest"       % "scalatest_2.11"    % "2.2.4"  % "test"
+    "io.spray"            %%  "spray-testkit"   % sprayV   % "test",
+    "org.scalatest"       % "scalatest_2.11"    % "2.2.4"  % "test",
+    "com.orange.redis-embedded" % "embedded-redis" % "0.6" % "test"
   )
 }
 

--- a/src/main/scala/info/lindblad/pedanticpadlock/bootstrap/Configuration.scala
+++ b/src/main/scala/info/lindblad/pedanticpadlock/bootstrap/Configuration.scala
@@ -1,9 +1,10 @@
 package info.lindblad.pedanticpadlock.bootstrap
 
+import java.net.URI
 import java.util.concurrent.TimeUnit
 
 import scala.concurrent.duration.FiniteDuration
-import scala.util.Properties
+import scala.util.{Try, Properties}
 import com.typesafe.config.ConfigFactory
 
 object Configuration {
@@ -18,4 +19,27 @@ object Configuration {
   lazy val port = Properties.envOrElse("PORT", "1337").toInt
 
   lazy val scheduledInterval: FiniteDuration = duration("scheduled-interval", TimeUnit.SECONDS)
+
+  /**
+   * Attempt to retrieve Redis connection details in the following order:
+   *
+   * 1) REDISCLOUD_URL environment variable (Heroku)
+   * 2) pedantic-padlock.redis-url in application.conf
+   *
+   * @return Option[RedisConfiguration]
+   */
+  def redis: Option[RedisConfiguration] = {
+    Properties.envOrSome("REDISCLOUD_URL", Try(values.getString("redis-url")).toOption) match {
+      case Some(redisUrl) => {
+        val redisUri = new URI(redisUrl)
+        val host = redisUri.getHost()
+        val port = redisUri.getPort()
+        val secret = Try(redisUri.getUserInfo().split(":",2).last).toOption
+        Some(RedisConfiguration(host, port, secret))
+      }
+      case _ => None
+    }
+  }
 }
+
+case class RedisConfiguration(host: String, port: Int, secret: Option[String])

--- a/src/main/scala/info/lindblad/pedanticpadlock/bootstrap/Main.scala
+++ b/src/main/scala/info/lindblad/pedanticpadlock/bootstrap/Main.scala
@@ -6,13 +6,15 @@ import akka.actor.{ActorSystem, Props}
 import akka.io.IO
 import akka.pattern.ask
 import akka.util.Timeout
-import info.lindblad.pedanticpadlock.model.{InMemoryScanStateStorage, ScanState}
+import com.redis.RedisClient
+import info.lindblad.pedanticpadlock.model.{RedisScanStateStorage, ScanStateStorage, InMemoryScanStateStorage, ScanState}
 import info.lindblad.pedanticpadlock.services.{ScanService, EventLoop}
+import info.lindblad.pedanticpadlock.util.Logging
 import spray.can.Http
 
 import scala.concurrent.duration._
 
-object Main extends App {
+object Main extends App with Logging {
 
   import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -20,7 +22,20 @@ object Main extends App {
 
   val service = system.actorOf(Props[HttpRequestActor])
 
-  val scanStateStorage = new InMemoryScanStateStorage(new ConcurrentHashMap[String, ScanState]())
+  val scanStateStorage: ScanStateStorage = {
+    Configuration.redis match {
+      case Some(redisConfiguration) => {
+        logger.info(s"Got Redis configuration: ${redisConfiguration.host}:${redisConfiguration.port}. Creating new Redis client.")
+        val redisClient = new RedisClient(host = redisConfiguration.host, port = redisConfiguration.port, secret = redisConfiguration.secret)
+        new RedisScanStateStorage(redisClient)
+      }
+      case _ => {
+        logger.info(s"No Redis configuration found. Using in memory data store.")
+        new InMemoryScanStateStorage(new ConcurrentHashMap[String, ScanState]())
+      }
+    }
+  }
+
   system.scheduler.schedule(
     Configuration.scheduledInterval,
     Configuration.scheduledInterval)(

--- a/src/main/scala/info/lindblad/pedanticpadlock/model/Model.scala
+++ b/src/main/scala/info/lindblad/pedanticpadlock/model/Model.scala
@@ -1,19 +1,15 @@
 package info.lindblad.pedanticpadlock.model
 
 /* This represents the current state of a scan */
-abstract class ScanState(val domainName: String) {
-
-  def currentTime() = System.currentTimeMillis()
-
-  val timeCreated: Long = currentTime()
+trait ScanState {
 
 }
 
-class NotProcessed(override val domainName: String) extends ScanState(domainName: String)
+class NotProcessed(val domainName: String, val timeCreated: Long = System.currentTimeMillis()) extends ScanState
 
-class AwaitingResult(override val domainName: String, val scanReport: ScanReport, val timesPolled: Int = 0) extends ScanState(domainName: String)
+class AwaitingResult(val domainName: String, val scanReport: ScanReport, val timesPolled: Int = 0, val timeCreated: Long = System.currentTimeMillis()) extends ScanState
 
-class FinishedResult(override val domainName: String, val scanReport: ScanReport) extends ScanState(domainName: String) {
+class FinishedResult(val domainName: String, val scanReport: ScanReport, val timeCreated: Long = System.currentTimeMillis()) extends ScanState {
 
   def isExpired(now: Long, validDuration: Long): Boolean = {
     val expirationTime = timeCreated + validDuration

--- a/src/main/scala/info/lindblad/pedanticpadlock/model/ScanStateStorage.scala
+++ b/src/main/scala/info/lindblad/pedanticpadlock/model/ScanStateStorage.scala
@@ -2,23 +2,65 @@ package info.lindblad.pedanticpadlock.model
 
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.JavaConversions._
+import com.redis.RedisClient
+import info.lindblad.pedanticpadlock.util.{Logging, JsonUtil}
+import org.json4s.JsonAST._
 
+import scala.collection.JavaConversions._
+import scala.collection.immutable.::
+import scala.collection.mutable.ListBuffer
+
+/**
+ * Generic storage trait for scan states
+ *
+ * Can be used to implement in memory storage
+ * or as a proxy for database calls
+ */
 trait ScanStateStorage {
 
+  /**
+   * Get scan state for domain name
+   * @param domainName
+   * @return Option[ScanState]
+   */
   def get(domainName: String): Option[ScanState]
 
+  /**
+   * Get scan state for domain name if it exists
+   *
+   * If the scan state does not exist, add it as unprocessed
+   *
+   * @param domainName
+   * @return Option[ScanState]
+   */
   def getOrPut(domainName: String): Option[ScanState]
 
+  /**
+   * Update scan state for domain name
+   * @param domainName
+   * @param scanState
+   */
   def put(domainName: String, scanState: ScanState): Unit
 
+  /**
+   * Add domain name
+   * @param domainName
+   */
   def add(domainName: String): Unit
 
+  /**
+   * Get all domain names and their current scan state
+   * @return allScanStates
+   */
   def getAll(): Seq[(String, ScanState)]
 
 }
 
-class InMemoryScanStateStorage(val scanStateMap: ConcurrentHashMap[String, ScanState]) extends ScanStateStorage {
+/**
+ * Adheres to the above storage trait and uses a concurrent hash map
+ * @param scanStateMap
+ */
+class InMemoryScanStateStorage(scanStateMap: ConcurrentHashMap[String, ScanState]) extends ScanStateStorage {
 
   def get(domainName: String): Option[ScanState] = Option(scanStateMap.get(domainName))
 
@@ -37,5 +79,56 @@ class InMemoryScanStateStorage(val scanStateMap: ConcurrentHashMap[String, ScanS
   def add(domainName: String) = scanStateMap.putIfAbsent(domainName, new NotProcessed(domainName))
 
   def getAll: Seq[(String, ScanState)] = scanStateMap.entrySet.map(entry => (entry.getKey, entry.getValue)).toList
+}
+
+/**
+ * Adheres to the above storage trait and uses Redis
+ * @param redisClient
+ */
+class RedisScanStateStorage(redisClient: RedisClient) extends ScanStateStorage with Logging {
+
+  def get(domainName: String): Option[ScanState] = {
+    redisClient.get(domainName) match {
+      case Some(scanStateJson) => {
+        JsonUtil.fromJSONOption[ScanState](scanStateJson)
+      }
+    }
+  }
+
+  def getOrPut(domainName: String): Option[ScanState] = {
+    redisClient.get(domainName) match {
+      case Some(scanStateJson) => JsonUtil.fromJSONOption[ScanState](scanStateJson)
+      case _ => {
+        put(domainName, new NotProcessed(domainName))
+        None
+      }
+    }
+  }
+
+  def put(domainName: String, scanState: ScanState) = {
+    redisClient.set(domainName, JsonUtil.toJSON(scanState))
+  }
+
+  def add(domainName: String) = {
+    redisClient.setnx(domainName,JsonUtil.toJSON(new NotProcessed(domainName)))
+  }
+
+  def getAll: Seq[(String, ScanState)] = {
+    val scanStateEntries = new ListBuffer[(String, ScanState)]()
+    redisClient.keys() match {
+      case Some(listOfKeys) => {
+        listOfKeys.foreach(key => {
+          key match {
+            case Some(validKey) => {
+              get(validKey) match {
+                case Some(scanState) => scanStateEntries.append((validKey, scanState))
+              }
+            }
+          }
+        })
+      }
+    }
+    scanStateEntries.toList
+  }
 
 }

--- a/src/main/scala/info/lindblad/pedanticpadlock/services/ScanService.scala
+++ b/src/main/scala/info/lindblad/pedanticpadlock/services/ScanService.scala
@@ -27,45 +27,45 @@ object ScanService extends ScanStateProcessing with Logging {
     }
   }
 
-    def startScan(notProcessed: NotProcessed): ScanState = {
-      val warningDaysBeforeExpiry = Try(Configuration.values.getInt("scan.warning-days-before-expiry")).getOrElse(30)
-      ConnectionProbeService.probe(notProcessed.domainName) match {
-        case ConnectionProbeResult(false, _) => {
-          logger.info("Java cannot connect to {}", notProcessed.domainName)
-          new FinishedResult(notProcessed.domainName, ScanReport(grade = Some("F"), reason = Some("Java cannot connect"), canConnect = false))
-        }
-        case ConnectionProbeResult(true, Some(daysUntilExpiration)) if (daysUntilExpiration <= warningDaysBeforeExpiry) => {
-          logger.info("Certificate for {} is expiring soon", notProcessed.domainName)
-          new FinishedResult(notProcessed.domainName, ScanReport(grade = Some(daysUntilExpiration.toString), reason = Some("Certificate about to expire soon"), canConnect = false))
-        }
-        case ConnectionProbeResult(true, Some(daysUntilExpiration)) if (daysUntilExpiration > warningDaysBeforeExpiry) => {
-          logger.info("Could connect to {} and certificate expiration is more than {} days away", notProcessed.domainName, warningDaysBeforeExpiry)
-          pollScan(new AwaitingResult(notProcessed.domainName, ScanReport(canConnect = true, daysUntilExpiration = Some(daysUntilExpiration))))
-        }
-        case _ => {
-          notProcessed
-        }
+  def startScan(notProcessed: NotProcessed): ScanState = {
+    val warningDaysBeforeExpiry = Try(Configuration.values.getInt("scan.warning-days-before-expiry")).getOrElse(30)
+    ConnectionProbeService.probe(notProcessed.domainName) match {
+      case ConnectionProbeResult(false, _) => {
+        logger.info("Java cannot connect to {}", notProcessed.domainName)
+        new FinishedResult(notProcessed.domainName, ScanReport(grade = Some("F"), reason = Some("Java cannot connect"), canConnect = false))
+      }
+      case ConnectionProbeResult(true, Some(daysUntilExpiration)) if (daysUntilExpiration <= warningDaysBeforeExpiry) => {
+        logger.info("Certificate for {} is expiring soon", notProcessed.domainName)
+        new FinishedResult(notProcessed.domainName, ScanReport(grade = Some(daysUntilExpiration.toString), reason = Some("Certificate about to expire soon"), canConnect = false))
+      }
+      case ConnectionProbeResult(true, Some(daysUntilExpiration)) if (daysUntilExpiration > warningDaysBeforeExpiry) => {
+        logger.info("Could connect to {} and certificate expiration is more than {} days away", notProcessed.domainName, warningDaysBeforeExpiry)
+        pollScan(new AwaitingResult(notProcessed.domainName, ScanReport(canConnect = true, daysUntilExpiration = Some(daysUntilExpiration))))
+      }
+      case _ => {
+        notProcessed
       }
     }
+  }
 
-    def pollScan(awaitingResult: AwaitingResult): ScanState = {
-      logger.info(s"Polling Qualsys report for ${awaitingResult.domainName}")
-      logger.info(s"${awaitingResult.timesPolled} times polled previously")
-      SslLabsService().analyse(awaitingResult.domainName) match {
-        case None => new AwaitingResult(
-          domainName = awaitingResult.domainName,
-          scanReport = awaitingResult.scanReport,
-          awaitingResult.timesPolled + 1
+  def pollScan(awaitingResult: AwaitingResult): ScanState = {
+    logger.info(s"Polling Qualsys report for ${awaitingResult.domainName}")
+    logger.info(s"${awaitingResult.timesPolled} times polled previously")
+    SslLabsService().analyse(awaitingResult.domainName) match {
+      case None => new AwaitingResult(
+        domainName = awaitingResult.domainName,
+        scanReport = awaitingResult.scanReport,
+        awaitingResult.timesPolled + 1
+      )
+      case Some(report) => new FinishedResult(
+        awaitingResult.domainName,
+        scanReport = ScanReport(
+          canConnect = true,
+          grade = Some(report.grade),
+          reason = Some("Grade given by Qualys SSL Labs")
         )
-        case Some(report) => new FinishedResult(
-          awaitingResult.domainName,
-          scanReport = ScanReport(
-            canConnect = true,
-            grade = Some(report.grade),
-            reason = Some("Grade given by Qualys SSL Labs")
-          )
-        )
-      }
+      )
     }
+  }
 
 }

--- a/src/main/scala/info/lindblad/pedanticpadlock/util/JsonUtil.scala
+++ b/src/main/scala/info/lindblad/pedanticpadlock/util/JsonUtil.scala
@@ -1,0 +1,21 @@
+package info.lindblad.pedanticpadlock.util
+
+import info.lindblad.pedanticpadlock.model._
+import org.json4s._
+import org.json4s.ShortTypeHints
+import org.json4s.native.Serialization
+import org.json4s.native.Serialization.{read, write}
+
+import scala.util.Try
+
+object JsonUtil {
+
+  implicit val formats = Serialization.formats(ShortTypeHints(List(classOf[NotProcessed], classOf[AwaitingResult], classOf[FinishedResult], classOf[ScanReport], classOf[SslLabsReport])))
+
+  def toJSON(objectToWrite: AnyRef): String = write(objectToWrite)
+
+  def fromJSONOption[T](jsonString: String)(implicit mf: Manifest[T]): Option[T] = {
+    Try(read[T](jsonString)).toOption
+  }
+
+}

--- a/src/test/scala/JsonUtilSpec.scala
+++ b/src/test/scala/JsonUtilSpec.scala
@@ -1,0 +1,32 @@
+import info.lindblad.pedanticpadlock.model._
+import info.lindblad.pedanticpadlock.util.JsonUtil
+import org.scalatest.{FlatSpec, Matchers}
+
+class JsonUtilSpec extends FlatSpec with Matchers {
+
+  "JsonUtil" should "deserialize/serialize NotProcessed correctly" in {
+    val notProcessedJson = JsonUtil.toJSON(new NotProcessed("niklaslindblad.se"))
+    val notProcessed = JsonUtil.fromJSONOption[ScanState](notProcessedJson).get
+    notProcessed.isInstanceOf[NotProcessed] should be(true)
+  }
+
+  it should "deserialize/serialzie AwaitingResult correctly" in {
+    val awaitingResultJson = JsonUtil.toJSON(new AwaitingResult("niklaslindblad.se", ScanReport(canConnect = true)))
+    val awaitingResult = JsonUtil.fromJSONOption[ScanState](awaitingResultJson).get
+    awaitingResult.isInstanceOf[AwaitingResult] should be(true)
+  }
+
+  it should "deserialize/serialize FinishedResult correctly" in {
+    val finishedResultJson = JsonUtil.toJSON(new FinishedResult("niklaslindblad.se", ScanReport(canConnect = true, sslLabsReport = Some(SslLabsReport("A+", false, false, false, 2048, "SHA")))))
+    val finishedResult = JsonUtil.fromJSONOption[ScanState](finishedResultJson).get
+    finishedResult.isInstanceOf[FinishedResult] should be(true)
+  }
+
+  it should "preserve creation timestamp correctly" in {
+    val finishedResultToBeSerialized = new FinishedResult("niklaslindblad.se", scanReport = ScanReport(canConnect = true, sslLabsReport = Some(SslLabsReport("A+", false, false, false, 2048, "SHA"))))
+    val finishedResultJson = JsonUtil.toJSON(finishedResultToBeSerialized)
+    val finishedResultDeserialized: FinishedResult = JsonUtil.fromJSONOption[FinishedResult](finishedResultJson).get
+    finishedResultDeserialized.timeCreated should be (finishedResultToBeSerialized.timeCreated)
+  }
+
+}

--- a/src/test/scala/RedisScanStateStorageSpec.scala
+++ b/src/test/scala/RedisScanStateStorageSpec.scala
@@ -1,0 +1,46 @@
+import com.redis.RedisClient
+import info.lindblad.pedanticpadlock.model.{ScanReport, AwaitingResult, NotProcessed, RedisScanStateStorage}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import redis.embedded.RedisServer
+
+class RedisScanStateStorageSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+
+  val redisServer = new RedisServer(16379)
+
+  override def beforeAll() = {
+    redisServer.start()
+    super.beforeAll()
+  }
+
+  override def afterAll() = {
+    redisClient.flushall
+    redisServer.stop()
+    super.afterAll()
+  }
+
+  def redisClient: RedisClient = {
+    val client = new RedisClient("127.0.0.1", 16379)
+    client.flushall
+    client
+  }
+
+  it should "add new domain names to the database if it does not already exist" in {
+    val client = redisClient
+    val scanStateStorage = new RedisScanStateStorage(client)
+    scanStateStorage.add("example.com")
+    val allEntries = scanStateStorage.getAll
+    allEntries.head._1 should be ("example.com")
+    allEntries.head._2.isInstanceOf[NotProcessed] should be (true)
+  }
+
+  it should "update entry in database if domain name already exists" in {
+    val client = redisClient
+    val scanStateStorage = new RedisScanStateStorage(client)
+    scanStateStorage.add("example.com")
+    scanStateStorage.put("example.com", new AwaitingResult("example.com", ScanReport(canConnect = true)))
+    val allEntries = scanStateStorage.getAll
+    allEntries.head._1 should be ("example.com")
+    allEntries.head._2.isInstanceOf[AwaitingResult] should be (true)
+  }
+
+}


### PR DESCRIPTION
Add support for Redis, with the following configuration priority:
1. `REDISCLOUD_URL` environment variable (default for Heroku with Redis To Go addon)
2. `pedantic-padlock.redis-url` in application.conf
3. Fall back to in-memory data store

Scan states are persisted and last between application restarts.

The trait `ScanStateStorage` can be used to add support for new databases.
