### PR TITLE
Improve SSL Labs API polling

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -17,6 +17,11 @@ pedantic-padlock {
     warning-days-before-expiry = 30
   }
 
+  ssl-labs {
+    # How often to poll SSL Labs API during an ongoing scan
+    poll-interval = 120000 # Milliseconds
+  }
+
   # Badge cache settings
   badge {
     cache {

--- a/src/main/scala/info/lindblad/pedanticpadlock/bootstrap/Configuration.scala
+++ b/src/main/scala/info/lindblad/pedanticpadlock/bootstrap/Configuration.scala
@@ -20,6 +20,8 @@ object Configuration {
 
   lazy val scheduledInterval: FiniteDuration = duration("scheduled-interval", TimeUnit.SECONDS)
 
+  lazy val sslLabsPollInterval: Long = values.getLong("ssl-labs.poll-interval")
+
   /**
    * Attempt to retrieve Redis connection details in the following order:
    *

--- a/src/main/scala/info/lindblad/pedanticpadlock/model/Model.scala
+++ b/src/main/scala/info/lindblad/pedanticpadlock/model/Model.scala
@@ -7,7 +7,7 @@ trait ScanState {
 
 class NotProcessed(val domainName: String, val timeCreated: Long = System.currentTimeMillis()) extends ScanState
 
-class AwaitingResult(val domainName: String, val scanReport: ScanReport, val timesPolled: Int = 0, val timeCreated: Long = System.currentTimeMillis()) extends ScanState
+class AwaitingResult(val domainName: String, val scanReport: ScanReport, val timesPolled: Int = 0, val lastTimePolled: Long = 0, val timeCreated: Long = System.currentTimeMillis()) extends ScanState
 
 class FinishedResult(val domainName: String, val scanReport: ScanReport, val timeCreated: Long = System.currentTimeMillis()) extends ScanState {
 

--- a/src/test/scala/EventLoopSpec.scala
+++ b/src/test/scala/EventLoopSpec.scala
@@ -8,13 +8,13 @@ class EventLoopSpec extends FlatSpec with Matchers {
 
   object TestScanStateProcessor extends ScanStateProcessing {
 
-    def process(currentState: ScanState, currentTime: Long, validDuration: Long, startScan: NotProcessed => ScanState = startScan, pollScan: AwaitingResult => ScanState = pollScan): ScanState = {
+    def process(currentState: ScanState, currentTime: Long, validDuration: Long, startScan: (NotProcessed, Long) => ScanState = startScan, pollScan: (AwaitingResult, Long) => ScanState = pollScan): ScanState = {
       ScanService.process(currentState, currentTime, validDuration, TestScanStateProcessor.startScan, TestScanStateProcessor.pollScan)
     }
 
-    def startScan(notProcessed: NotProcessed): ScanState = new AwaitingResult(notProcessed.domainName, ScanReport(canConnect = true))
+    def startScan(notProcessed: NotProcessed, currentTime: Long): ScanState = new AwaitingResult(notProcessed.domainName, ScanReport(canConnect = true))
 
-    def pollScan(awaitingResult: AwaitingResult): FinishedResult = new FinishedResult(awaitingResult.domainName, ScanReport(canConnect = true))
+    def pollScan(awaitingResult: AwaitingResult, currentTime: Long): FinishedResult = new FinishedResult(awaitingResult.domainName, ScanReport(canConnect = true))
 
   }
 


### PR DESCRIPTION
Keep track of the last time the SSL Labs API was polled for a certain
domain and only do a new poll if one polling interval has passed.

Much simpler than tracking the state of the `X-Max-Assessments` header returned (although that might be a good idea for the future).
